### PR TITLE
Added link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ForkPlayground
-A library to implement the Process Forking attack described in this blog post. 
+A library to implement the Process Forking attack described in this [blog post](https://billdemirkapi.me/abusing-windows-implementation-of-fork-for-stealthy-memory-operations/). 
 
 **ForkLib** - C++ library that implements the Process Forking attack.
 


### PR DESCRIPTION
The README references your blog post and is worded in such a way that it might be linked to it, but isn't.